### PR TITLE
[Fix] Android RSSI success callback

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -3126,6 +3126,7 @@ private final class BluetoothGattCallbackExtends extends BluetoothGattCallback
     {
       addProperty(returnObj, keyStatus, statusRssi);
       addProperty(returnObj, keyRssi, rssi);
+      addProperty(returnObj, keyAddress, address);
       callbackContext.success(returnObj);
     }
     //Else it failed


### PR DESCRIPTION
Android platform's RSSI success callback doesn't contain address information.
Adding a addProperty solves this problem.
